### PR TITLE
BUGFIX: responsive meta tag returned

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Tarot From The Divide</title>
   </head>
   <body>


### PR DESCRIPTION
oops got too aggressive removing so called boilerplate

removed the meta tag needed for responsive CSS in my cleanup.
<meta name="viewport" content="width=device-width, initial-scale=1" />