### PR TITLE
CSS Styling fix for mobile display offset to right

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+html, body {
+  overflow-x: hidden;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
Fix 1, assuming issue is the off-canvas slide-in menus: NavMenu.js's .navPanel is position: fixed and moved off-screen via transform: translateX(-100%) when closed — it's still 250px wide, just shifted left of x=0. 

- added overflow-x: hidden to html, body in src/index.css