### PR TITLE
firefox browser display bug

### DIFF
--- a/src/components/NavMenu.css
+++ b/src/components/NavMenu.css
@@ -29,6 +29,7 @@
   font-family: Cinzel;
   box-sizing: border-box;
   padding-top: 60px;
+  contain: layout;
 }
 
 .navPanel-open {


### PR DESCRIPTION
Right-offset content on reading page looks bad.

Firefox-specific quirk: Gecko computes the page's horizontal scrollable area including position: fixed descendants that are pushed off-screen via transform, even when an ancestor has overflow-x: hidden