### PR TITLE
Revert "Gallery Lazy Load Images"

### DIFF
--- a/src/pages/GalleryPage.jsx
+++ b/src/pages/GalleryPage.jsx
@@ -95,7 +95,7 @@ function GalleryPage() {
             tarotCardJson.map(card =>{
               return card.tag === "major" ? (
               <div className="card-wrapper" onClick={()=> openModal(card)}>
-                <img src={uriPrefix + card.uri}  alt={card.uri} loading="lazy"/>
+                <img src={uriPrefix + card.uri}  alt={card.uri}/>
                 <div className="title">{card["tarot-number"]+" "+card.name}</div>
               </div>) : null
             })


### PR DESCRIPTION
Reverts WWotring/divide-tarot-app#64

Site unavailable on deploy. Appears to be a DOM node issue I did not see locally.